### PR TITLE
5 beam geometry

### DIFF
--- a/docs/examples/5-structure-ie-model-minimum-free.json
+++ b/docs/examples/5-structure-ie-model-minimum-free.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "test-structure",
     "population": "ie-population",
     "timestamp": 1588007840000000000,
@@ -14,10 +14,13 @@
                         "type": "beam"
                     },
                     "geometry": {
-                        "type": {
-                            "name": "beam",
+                        "type":{
+                            "name":"solid",
                             "type": {
-                                "name": "rectangular"
+                                "name": "beam",
+                                "type": {
+                                    "name": "rectangular"
+                                }
                             }
                         }
                     },

--- a/docs/examples/6-structure-ie-model-minimum-grounded.json
+++ b/docs/examples/6-structure-ie-model-minimum-grounded.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "test-structure",
     "population": "ie-population",
     "timestamp": 1588007841000000000,
@@ -19,9 +19,12 @@
                     },
                     "geometry": {
                         "type": {
-                            "name": "beam",
+                            "name": "shell",
                             "type": {
-                                "name": "rectangular"
+                                "name": "beam",
+                                "type": {
+                                    "name": "rectangular"
+                                }
                             }
                         }
                     },

--- a/model-irreducible-element-geometry-data.json
+++ b/model-irreducible-element-geometry-data.json
@@ -279,9 +279,9 @@
                             }
                         },
                         {
-                            "oneOf":[
+                            "oneOf": [
                                 {
-                                    "allOf":[
+                                    "allOf": [
                                         {
                                             "oneOf": [
                                                 {
@@ -323,7 +323,7 @@
                                             ]
                                         },
                                         {
-                                            "oneOf":[
+                                            "oneOf": [
                                                 {
                                                     "properties": {
                                                         "type": {
@@ -432,7 +432,7 @@
                                     ]
                                 },
                                 {
-                                    "allOf":[
+                                    "allOf": [
                                         {
                                             "properties": {
                                                 "type": {
@@ -447,7 +447,7 @@
                                             }
                                         },
                                         {
-                                            "oneOf":[
+                                            "oneOf": [
                                                 {
                                                     "properties": {
                                                         "type": {
@@ -458,7 +458,9 @@
                                                                             "properties": {
                                                                                 "name": {
                                                                                     "enum": [
-                                                                                        "i-beam"
+                                                                                        "i-beam",
+                                                                                        "t-beam",
+                                                                                        "c-beam"
                                                                                     ]
                                                                                 }
                                                                             }
@@ -469,26 +471,153 @@
                                                         },
                                                         "dimensions": {
                                                             "required": [
-                                                                "d",
-                                                                "h",
-                                                                "s",
-                                                                "b",
-                                                                "t"
+                                                                "width",
+                                                                "height",
+                                                                "webThickness",
+                                                                "flangeThickness"
                                                             ],
                                                             "properties": {
-                                                                "d": {
+                                                                "width": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 },
-                                                                "h": {
+                                                                "height": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 },
-                                                                "s": {
+                                                                "webThickness": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 },
-                                                                "b": {
+                                                                "flangeThickness": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "enum": [
+                                                                                        "l-beam"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "width",
+                                                                "height",
+                                                                "thickness",
+                                                                "angle"
+                                                            ],
+                                                            "properties": {
+                                                                "width": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 },
-                                                                "t": {
+                                                                "height": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "thickness": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "angle": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/angular"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "enum": [
+                                                                                        "y-beam",
+                                                                                        "ye-beam",
+                                                                                        "m-beam"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "height",
+                                                                "baseWidth",
+                                                                "topWidth"
+                                                            ],
+                                                            "properties": {
+                                                                "height": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "baseWidth": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "topWidth": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "enum": [
+                                                                                        "u-beam",
+                                                                                        "um-beam"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "height",
+                                                                "baseWidth",
+                                                                "topWidth",
+                                                                "openingWidth"
+                                                            ],
+                                                            "properties": {
+                                                                "height": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "baseWidth": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "topWidth": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "openingWidth": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 }
                                                             }

--- a/model-irreducible-element-geometry-data.json
+++ b/model-irreducible-element-geometry-data.json
@@ -151,7 +151,44 @@
             ],
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/type"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/type"
+                        },
+                        {
+                            "required": [
+                                "type"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/definitions/type"
+                                        },
+                                        {
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "properties": {
+                                                "type": {
+                                                    "allOf": [
+                                                        {
+                                                            "$ref": "#/definitions/type"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    ]
                 },
                 "bounding": {
                     "bsonType": "object",
@@ -217,27 +254,17 @@
                         {
                             "properties": {
                                 "type": {
-                                    "required": [
-                                        "type"
-                                    ],
                                     "properties": {
-                                        "name": {
-                                            "enum": [
-                                                "beam"
-                                            ]
-                                        },
                                         "type": {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/type"
-                                                },
-                                                {
-                                                    "additionalProperties": false
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "beam"
+                                                    ]
                                                 }
-                                            ]
+                                            }
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "dimensions": {
                                     "required": [
@@ -252,341 +279,9 @@
                             }
                         },
                         {
-                            "oneOf": [
+                            "oneOf":[
                                 {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "rectangular"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "required": [
-                                                "width",
-                                                "height"
-                                            ],
-                                            "properties": {
-                                                "width": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "height": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "circular"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "required": [
-                                                "radius"
-                                            ],
-                                            "properties": {
-                                                "radius": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "i-beam"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "required": [
-                                                "d",
-                                                "h",
-                                                "s",
-                                                "b",
-                                                "t"
-                                            ],
-                                            "properties": {
-                                                "d": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "h": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "s": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "b": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "t": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "other"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "additionalProperties": {
-                                                "oneOf": [
-                                                    {
-                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                    },
-                                                    {
-                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
-                                                    }
-                                                ]
-                                            },
-                                            "minProperties": 2
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "type": {
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "properties": {
-                                        "name": {
-                                            "enum": [
-                                                "plate"
-                                            ]
-                                        },
-                                        "type": {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/type"
-                                                },
-                                                {
-                                                    "additionalProperties": false
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "dimensions": {
-                                    "required": [
-                                        "thickness"
-                                    ],
-                                    "properties": {
-                                        "thickness": {
-                                            "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "oneOf": [
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "rectangular"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "required": [
-                                                "width",
-                                                "length"
-                                            ],
-                                            "properties": {
-                                                "width": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                },
-                                                "length": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "circular"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "required": [
-                                                "radius"
-                                            ],
-                                            "properties": {
-                                                "radius": {
-                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "other"
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "dimensions": {
-                                            "additionalProperties": {
-                                                "oneOf": [
-                                                    {
-                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                    },
-                                                    {
-                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
-                                                    }
-                                                ]
-                                            },
-                                            "minProperties": 2
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "allOf": [
-                        {
-                            "properties": {
-                                "type": {
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "properties": {
-                                        "type": {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/type"
-                                                },
-                                                {
-                                                    "required": [
-                                                        "type"
-                                                    ],
-                                                    "properties": {
-                                                        "type": {
-                                                            "allOf": [
-                                                                {
-                                                                    "$ref": "#/definitions/type"
-                                                                },
-                                                                {
-                                                                    "additionalProperties": false
-                                                                }
-                                                            ]
-                                                        }
-                                                    },
-                                                    "additionalProperties": false
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "oneOf": [
-                                {
-                                    "allOf": [
-                                        {
-                                            "properties": {
-                                                "type": {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "name": {
-                                                                    "enum": [
-                                                                        "translate"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
+                                    "allOf":[
                                         {
                                             "oneOf": [
                                                 {
@@ -628,7 +323,7 @@
                                             ]
                                         },
                                         {
-                                            "oneOf": [
+                                            "oneOf":[
                                                 {
                                                     "properties": {
                                                         "type": {
@@ -639,7 +334,7 @@
                                                                             "properties": {
                                                                                 "name": {
                                                                                     "enum": [
-                                                                                        "cuboid"
+                                                                                        "rectangular"
                                                                                     ]
                                                                                 }
                                                                             }
@@ -650,14 +345,10 @@
                                                         },
                                                         "dimensions": {
                                                             "required": [
-                                                                "length",
                                                                 "width",
                                                                 "height"
                                                             ],
                                                             "properties": {
-                                                                "length": {
-                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                },
                                                                 "width": {
                                                                     "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                                 },
@@ -666,7 +357,8 @@
                                                                 }
                                                             }
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 },
                                                 {
                                                     "properties": {
@@ -678,7 +370,7 @@
                                                                             "properties": {
                                                                                 "name": {
                                                                                     "enum": [
-                                                                                        "sphere"
+                                                                                        "circular"
                                                                                     ]
                                                                                 }
                                                                             }
@@ -697,42 +389,8 @@
                                                                 }
                                                             }
                                                         }
-                                                    }
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "type": {
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "properties": {
-                                                                                "name": {
-                                                                                    "enum": [
-                                                                                        "cylinder"
-                                                                                    ]
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "dimensions": {
-                                                            "required": [
-                                                                "radius",
-                                                                "length"
-                                                            ],
-                                                            "properties": {
-                                                                "radius": {
-                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                },
-                                                                "length": {
-                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                }
-                                                            }
-                                                        }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 },
                                                 {
                                                     "properties": {
@@ -766,15 +424,125 @@
                                                             },
                                                             "minProperties": 2
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
                                             ]
                                         }
                                     ]
                                 },
                                 {
-                                    "allOf": [
+                                    "allOf":[
                                         {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "name": {
+                                                            "enum": [
+                                                                "solid"
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "oneOf":[
+                                                {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "enum": [
+                                                                                        "i-beam"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "d",
+                                                                "h",
+                                                                "s",
+                                                                "b",
+                                                                "t"
+                                                            ],
+                                                            "properties": {
+                                                                "d": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "h": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "s": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "b": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "t": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "solid"
+                                            ]
+                                        },
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "plate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "dimensions": {
+                                    "required": [
+                                        "thickness"
+                                    ],
+                                    "properties": {
+                                        "thickness": {
+                                            "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
                                             "properties": {
                                                 "type": {
                                                     "properties": {
@@ -782,294 +550,601 @@
                                                             "properties": {
                                                                 "name": {
                                                                     "enum": [
-                                                                        "translateAndScale"
+                                                                        "rectangular"
                                                                     ]
                                                                 }
                                                             }
                                                         }
                                                     }
-                                                },
-                                                "faces": {
-                                                    "bsonType": "object",
-                                                    "title": "faces",
-                                                    "description": "the faces that describe the translate and scale operations within the bounding",
-                                                    "required": [
-                                                        "left",
-                                                        "right"
-                                                    ],
-                                                    "properties": {
-                                                        "left": {
-                                                            "$ref": "#/definitions/face"
-                                                        },
-                                                        "right": {
-                                                            "$ref": "#/definitions/face"
-                                                        }
-                                                    }
-                                                },
-                                                "dimensions": {
-                                                    "required": [
-                                                        "length"
-                                                    ],
-                                                    "properties": {
-                                                        "length": {
-                                                            "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                        }
-                                                    }
                                                 }
-                                            },
-                                            "dependencies": {
-                                                "bounding": [
-                                                    "faces"
-                                                ],
-                                                "faces": [
-                                                    "bounding"
-                                                ],
-                                                "dimensions": [
-                                                    "bounding",
-                                                    "faces"
-                                                ]
                                             }
                                         },
-                                        {
-                                            "oneOf": [
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "name": {
-                                                                    "enum": [
-                                                                        "solid"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        }
-                                                    }
+                                        "dimensions": {
+                                            "required": [
+                                                "width",
+                                                "length"
+                                            ],
+                                            "properties": {
+                                                "width": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                 },
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "name": {
-                                                                    "enum": [
-                                                                        "shell"
-                                                                    ]
-                                                                }
-                                                            }
-                                                        },
-                                                        "faces": {
-                                                            "properties": {
-                                                                "left": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "thickness"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "thickness": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "right": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "thickness"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "thickness": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
+                                                "length": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
                                                 }
-                                            ]
-                                        },
-                                        {
-                                            "oneOf": [
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "type": {
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "properties": {
-                                                                                "name": {
-                                                                                    "enum": [
-                                                                                        "cuboid"
-                                                                                    ]
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "faces": {
-                                                            "properties": {
-                                                                "left": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "width",
-                                                                                "height"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "width": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                },
-                                                                                "height": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "right": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "width",
-                                                                                "height"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "width": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                },
-                                                                                "height": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "type": {
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "properties": {
-                                                                                "name": {
-                                                                                    "enum": [
-                                                                                        "cylinder"
-                                                                                    ]
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "faces": {
-                                                            "properties": {
-                                                                "left": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "radius"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "radius": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "right": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "required": [
-                                                                                "radius"
-                                                                            ],
-                                                                            "properties": {
-                                                                                "radius": {
-                                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "type": {
-                                                            "properties": {
-                                                                "type": {
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "properties": {
-                                                                                "name": {
-                                                                                    "enum": [
-                                                                                        "other"
-                                                                                    ]
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "faces": {
-                                                            "properties": {
-                                                                "left": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "additionalProperties": {
-                                                                                "oneOf": [
-                                                                                    {
-                                                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                    },
-                                                                                    {
-                                                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
-                                                                                    }
-                                                                                ]
-                                                                            },
-                                                                            "minProperties": 2
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "right": {
-                                                                    "properties": {
-                                                                        "dimensions": {
-                                                                            "additionalProperties": {
-                                                                                "oneOf": [
-                                                                                    {
-                                                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
-                                                                                    },
-                                                                                    {
-                                                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
-                                                                                    }
-                                                                                ]
-                                                                            },
-                                                                            "minProperties": 2
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            ]
+                                            }
                                         }
-                                    ]
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "circular"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "required": [
+                                                "radius"
+                                            ],
+                                            "properties": {
+                                                "radius": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "other"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "additionalProperties": {
+                                                "oneOf": [
+                                                    {
+                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                    },
+                                                    {
+                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
+                                                    }
+                                                ]
+                                            },
+                                            "minProperties": 2
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "translate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "solid"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "shell"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "required": [
+                                                "thickness"
+                                            ],
+                                            "properties": {
+                                                "thickness": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "cuboid"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "required": [
+                                                "length",
+                                                "width",
+                                                "height"
+                                            ],
+                                            "properties": {
+                                                "length": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                },
+                                                "width": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                },
+                                                "height": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "sphere"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "required": [
+                                                "radius"
+                                            ],
+                                            "properties": {
+                                                "radius": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "cylinder"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "required": [
+                                                "radius",
+                                                "length"
+                                            ],
+                                            "properties": {
+                                                "radius": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                },
+                                                "length": {
+                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "other"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "dimensions": {
+                                            "additionalProperties": {
+                                                "oneOf": [
+                                                    {
+                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                    },
+                                                    {
+                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
+                                                    }
+                                                ]
+                                            },
+                                            "minProperties": 2
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "properties": {
+                                "type": {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "translateAndScale"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "faces": {
+                                    "bsonType": "object",
+                                    "title": "faces",
+                                    "description": "the faces that describe the translate and scale operations within the bounding",
+                                    "required": [
+                                        "left",
+                                        "right"
+                                    ],
+                                    "properties": {
+                                        "left": {
+                                            "$ref": "#/definitions/face"
+                                        },
+                                        "right": {
+                                            "$ref": "#/definitions/face"
+                                        }
+                                    }
+                                },
+                                "dimensions": {
+                                    "required": [
+                                        "length"
+                                    ],
+                                    "properties": {
+                                        "length": {
+                                            "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                        }
+                                    }
+                                }
+                            },
+                            "dependencies": {
+                                "bounding": [
+                                    "faces"
+                                ],
+                                "faces": [
+                                    "bounding"
+                                ],
+                                "dimensions": [
+                                    "bounding",
+                                    "faces"
+                                ]
+                            }
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "solid"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "name": {
+                                                    "enum": [
+                                                        "shell"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "faces": {
+                                            "properties": {
+                                                "left": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "thickness"
+                                                            ],
+                                                            "properties": {
+                                                                "thickness": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "thickness"
+                                                            ],
+                                                            "properties": {
+                                                                "thickness": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "cuboid"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "faces": {
+                                            "properties": {
+                                                "left": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "width",
+                                                                "height"
+                                                            ],
+                                                            "properties": {
+                                                                "width": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "height": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "width",
+                                                                "height"
+                                                            ],
+                                                            "properties": {
+                                                                "width": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                },
+                                                                "height": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "cylinder"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "faces": {
+                                            "properties": {
+                                                "left": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "radius"
+                                                            ],
+                                                            "properties": {
+                                                                "radius": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "required": [
+                                                                "radius"
+                                                            ],
+                                                            "properties": {
+                                                                "radius": {
+                                                                    "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "properties": {
+                                                "type": {
+                                                    "properties": {
+                                                        "type": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "other"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "faces": {
+                                            "properties": {
+                                                "left": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                    },
+                                                                    {
+                                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "minProperties": 2
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "properties": {
+                                                        "dimensions": {
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "$ref": "model-irreducible-element-data.json#/definitions/linear"
+                                                                    },
+                                                                    {
+                                                                        "$ref": "model-irreducible-element-data.json#/definitions/angular"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "minProperties": 2
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             ]
                         }

--- a/structure-data.json
+++ b/structure-data.json
@@ -16,7 +16,7 @@
             "title": "version number",
             "description": "the version of the schema that the document is compliant to",
             "enum": [
-                "1.1.1"
+                "1.2.0"
             ]
         },
         "name": {

--- a/tools/generate-irreducible-element-markdown.js
+++ b/tools/generate-irreducible-element-markdown.js
@@ -88,13 +88,24 @@ var mappings = [
     },
     {//Group Geometry -> Elements -> N -> Bounding to Shared, Cuboid -> Bounding
         source: [
-            ["geometry", "element", "beam rectangular", "bounding"],
-            ["geometry", "element", "beam circular", "bounding"],
-            ["geometry", "element", "beam i-beam", "bounding"],
-            ["geometry", "element", "beam other", "bounding"],
-            ["geometry", "element", "plate rectangular", "bounding"],
-            ["geometry", "element", "plate circular", "bounding"],
-            ["geometry", "element", "plate other", "bounding"],
+            ["geometry", "element", "solid beam rectangular", "bounding"],
+            ["geometry", "element", "shell beam rectangular", "bounding"],
+            ["geometry", "element", "solid beam circular", "bounding"],
+            ["geometry", "element", "shell beam circular", "bounding"],
+            ["geometry", "element", "solid beam i-beam", "bounding"],
+            ["geometry", "element", "solid beam t-beam", "bounding"],
+            ["geometry", "element", "solid beam c-beam", "bounding"],
+            ["geometry", "element", "solid beam l-beam", "bounding"],
+            ["geometry", "element", "solid beam y-beam", "bounding"],
+            ["geometry", "element", "solid beam ye-beam", "bounding"],
+            ["geometry", "element", "solid beam m-beam", "bounding"],
+            ["geometry", "element", "solid beam u-beam", "bounding"],
+            ["geometry", "element", "solid beam um-beam", "bounding"],
+            ["geometry", "element", "solid beam other", "bounding"],
+            ["geometry", "element", "shell beam other", "bounding"],
+            ["geometry", "element", "solid plate rectangular", "bounding"],
+            ["geometry", "element", "solid plate circular", "bounding"],
+            ["geometry", "element", "solid plate other", "bounding"],
             ["geometry", "element", "solid translate cuboid", "bounding"],
             ["geometry", "element", "shell translate cuboid", "bounding"],
             ["geometry", "element", "solid translate sphere", "bounding"],
@@ -135,24 +146,68 @@ var mappings = [
             ["bounding", "cuboid", "length"],//Bounding
             ["bounding", "cuboid", "width"],
             ["bounding", "cuboid", "height"],
-            ["geometry", "element", "beam rectangular", "dimensions", "length"],//Geometry -> Beam -> Rectangular -> Dimensions
-            ["geometry", "element", "beam rectangular", "dimensions", "width"],
-            ["geometry", "element", "beam rectangular", "dimensions", "height"],
-            ["geometry", "element", "beam circular", "dimensions", "length"],//Geometry -> Beam -> Circular -> Dimensions
-            ["geometry", "element", "beam circular", "dimensions", "radius"],
-            ["geometry", "element", "beam i-beam", "dimensions", "length"],//Geometry -> Beam -> I-Beam -> Dimensions
-            ["geometry", "element", "beam i-beam", "dimensions", "d"],
-            ["geometry", "element", "beam i-beam", "dimensions", "h"],
-            ["geometry", "element", "beam i-beam", "dimensions", "s"],
-            ["geometry", "element", "beam i-beam", "dimensions", "b"],
-            ["geometry", "element", "beam i-beam", "dimensions", "t"],
-            ["geometry", "element", "beam other", "dimensions", "length"],//Geometry -> Beam -> Other -> Dimensions
-            ["geometry", "element", "plate rectangular", "dimensions", "thickness"],//Geometry -> Plate -> Rectangular -> Dimensions
-            ["geometry", "element", "plate rectangular", "dimensions", "width"],
-            ["geometry", "element", "plate rectangular", "dimensions", "length"],
-            ["geometry", "element", "plate circular", "dimensions", "thickness"],//Geometry -> Plate -> Circular -> Dimensions
-            ["geometry", "element", "plate circular", "dimensions", "radius"],
-            ["geometry", "element", "plate other", "dimensions", "thickness"],//Geometry -> Plate -> Other -> Dimensions
+            ["geometry", "element", "solid beam rectangular", "dimensions", "length"],//Geometry -> Solid -> Beam -> Rectangular -> Dimensions
+            ["geometry", "element", "solid beam rectangular", "dimensions", "width"],
+            ["geometry", "element", "solid beam rectangular", "dimensions", "height"],
+            ["geometry", "element", "shell beam rectangular", "dimensions", "length"],//Geometry -> Shell -> Beam -> Rectangular -> Dimensions
+            ["geometry", "element", "shell beam rectangular", "dimensions", "width"],
+            ["geometry", "element", "shell beam rectangular", "dimensions", "height"],
+            ["geometry", "element", "shell beam rectangular", "dimensions", "thickness"],
+            ["geometry", "element", "solid beam circular", "dimensions", "length"],//Geometry -> Solid -> Beam -> Circular -> Dimensions
+            ["geometry", "element", "solid beam circular", "dimensions", "radius"],
+            ["geometry", "element", "shell beam circular", "dimensions", "length"],//Geometry -> Shell -> Beam -> Circular -> Dimensions
+            ["geometry", "element", "shell beam circular", "dimensions", "radius"],
+            ["geometry", "element", "shell beam circular", "dimensions", "thickness"],
+            ["geometry", "element", "solid beam i-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> I-Beam -> Dimensions
+            ["geometry", "element", "solid beam i-beam", "dimensions", "width"],
+            ["geometry", "element", "solid beam i-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam i-beam", "dimensions", "webThickness"],
+            ["geometry", "element", "solid beam i-beam", "dimensions", "flangeThickness"],
+            ["geometry", "element", "solid beam t-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> T-Beam -> Dimensions
+            ["geometry", "element", "solid beam t-beam", "dimensions", "width"],
+            ["geometry", "element", "solid beam t-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam t-beam", "dimensions", "webThickness"],
+            ["geometry", "element", "solid beam t-beam", "dimensions", "flangeThickness"],
+            ["geometry", "element", "solid beam c-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> C-Beam -> Dimensions
+            ["geometry", "element", "solid beam c-beam", "dimensions", "width"],
+            ["geometry", "element", "solid beam c-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam c-beam", "dimensions", "webThickness"],
+            ["geometry", "element", "solid beam c-beam", "dimensions", "flangeThickness"],
+            ["geometry", "element", "solid beam l-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> L-Beam -> Dimensions
+            ["geometry", "element", "solid beam l-beam", "dimensions", "width"],
+            ["geometry", "element", "solid beam l-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam l-beam", "dimensions", "thickness"],
+            ["geometry", "element", "solid beam y-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> Y-Beam -> Dimensions
+            ["geometry", "element", "solid beam y-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam y-beam", "dimensions", "baseWidth"],
+            ["geometry", "element", "solid beam y-beam", "dimensions", "topWidth"],
+            ["geometry", "element", "solid beam ye-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> YE-Beam -> Dimensions
+            ["geometry", "element", "solid beam ye-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam ye-beam", "dimensions", "baseWidth"],
+            ["geometry", "element", "solid beam ye-beam", "dimensions", "topWidth"],
+            ["geometry", "element", "solid beam m-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> M-Beam -> Dimensions
+            ["geometry", "element", "solid beam m-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam m-beam", "dimensions", "baseWidth"],
+            ["geometry", "element", "solid beam m-beam", "dimensions", "topWidth"],
+            ["geometry", "element", "solid beam u-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> U-Beam -> Dimensions
+            ["geometry", "element", "solid beam u-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam u-beam", "dimensions", "baseWidth"],
+            ["geometry", "element", "solid beam u-beam", "dimensions", "topWidth"],
+            ["geometry", "element", "solid beam u-beam", "dimensions", "openingWidth"],
+            ["geometry", "element", "solid beam um-beam", "dimensions", "length"],//Geometry -> Solid -> Beam -> UM-Beam -> Dimensions
+            ["geometry", "element", "solid beam um-beam", "dimensions", "height"],
+            ["geometry", "element", "solid beam um-beam", "dimensions", "baseWidth"],
+            ["geometry", "element", "solid beam um-beam", "dimensions", "topWidth"],
+            ["geometry", "element", "solid beam um-beam", "dimensions", "openingWidth"],
+            ["geometry", "element", "solid beam other", "dimensions", "length"],//Geometry -> Solid -> Beam -> Other -> Dimensions
+            ["geometry", "element", "shell beam other", "dimensions", "length"],//Geometry -> Shell -> Beam -> Other -> Dimensions
+            ["geometry", "element", "shell beam other", "dimensions", "thickness"],
+            ["geometry", "element", "solid plate rectangular", "dimensions", "thickness"],//Geometry -> Solid -> Plate -> Rectangular -> Dimensions
+            ["geometry", "element", "solid plate rectangular", "dimensions", "width"],
+            ["geometry", "element", "solid plate rectangular", "dimensions", "length"],
+            ["geometry", "element", "solid plate circular", "dimensions", "thickness"],//Geometry -> Solid -> Plate -> Circular -> Dimensions
+            ["geometry", "element", "solid plate circular", "dimensions", "radius"],
+            ["geometry", "element", "solid plate other", "dimensions", "thickness"],//Geometry -> Solid -> Plate -> Other -> Dimensions
             ["geometry", "element", "solid translate cuboid", "dimensions", "length"],//Geometry -> Solid -> Translate -> Cuboid -> Dimensions
             ["geometry", "element", "solid translate cuboid", "dimensions", "width"],
             ["geometry", "element", "solid translate cuboid", "dimensions", "height"],
@@ -192,8 +247,10 @@ var mappings = [
     },
     {//Group Geometry -> Elements -> N -> Dimensions -> * to Angular Dimension
         source: [
-            ["geometry", "element", "beam other", "dimensions", "*"],
-            ["geometry", "element", "plate other", "dimensions", "*"],
+            ["geometry", "element", "solid beam other", "dimensions", "*"],
+            ["geometry", "element", "shell beam other", "dimensions", "*"],
+            ["geometry", "element", "solid beam l-beam", "dimensions", "angle"],
+            ["geometry", "element", "solid plate other", "dimensions", "*"],
             ["geometry", "element", "solid translate other", "dimensions", "*"],
             ["geometry", "element", "shell translate other", "dimensions", "*"]
         ],
@@ -204,13 +261,24 @@ var mappings = [
     },
     {//Group Geometry -> Elements -> N -> Dimensions -> _ to Wildcard Dimension
         source: [
-            ["geometry", "element", "beam rectangular", "dimensions", "_"],
-            ["geometry", "element", "beam circular", "dimensions", "_"],
-            ["geometry", "element", "beam i-beam", "dimensions", "_"],
-            ["geometry", "element", "beam other", "dimensions", "_"],
-            ["geometry", "element", "plate rectangular", "dimensions", "_"],
-            ["geometry", "element", "plate circular", "dimensions", "_"],
-            ["geometry", "element", "plate other", "dimensions", "_"],
+            ["geometry", "element", "solid beam rectangular", "dimensions", "_"],
+            ["geometry", "element", "shell beam rectangular", "dimensions", "_"],
+            ["geometry", "element", "solid beam circular", "dimensions", "_"],
+            ["geometry", "element", "shell beam circular", "dimensions", "_"],
+            ["geometry", "element", "solid beam i-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam t-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam c-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam l-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam y-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam ye-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam m-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam u-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam um-beam", "dimensions", "_"],
+            ["geometry", "element", "solid beam other", "dimensions", "_"],
+            ["geometry", "element", "shell beam other", "dimensions", "_"],
+            ["geometry", "element", "solid plate rectangular", "dimensions", "_"],
+            ["geometry", "element", "solid plate circular", "dimensions", "_"],
+            ["geometry", "element", "solid plate other", "dimensions", "_"],
             ["geometry", "element", "solid translate cuboid", "dimensions", "_"],
             ["geometry", "element", "shell translate cuboid", "dimensions", "_"],
             ["geometry", "element", "solid translate sphere", "dimensions", "_"],
@@ -1167,6 +1235,7 @@ function mergeGeometryAttributesIntoProperties(geometryObject) {
     if (geometryObject["types"].length > 0 && typeof (geometryObject["properties"]["type"]) === typeof (undefined)) console.log("Error:Geometry Object has types but no type to merge");
     else if (typeof (geometryObject["properties"]["type"]["object"]) === typeof (undefined) || typeof (geometryObject["properties"]["type"]["object"]["name"]) === typeof (undefined)) console.log("Error: Missing type property declaration");
     else clonedObject["type"]["object"]["name"]["values"] = flatternTypeStack(geometryObject["types"]);
+    delete clonedObject["type"]["object"]["type"];
     //Merge in Dimensions
     if (geometryObject["dimensions"].length > 0 && typeof (geometryObject["properties"]["dimensions"]) === typeof (undefined)) console.log("Error:Geometry Object has dimensions but no additional property to merge");
     else if (typeof (geometryObject["properties"]["dimensions"]["object"]) === typeof (undefined) || typeof (geometryObject["properties"]["dimensions"]["object"]["_"]) === typeof (undefined)) console.log("Error: Missing additional property declaration");


### PR DESCRIPTION
To encapsulate the space within an element (hollow, etc), the named geometrical types (`beam` and `plate`) have been restructured so that they fall under the root types: `solid` and `shell`. In future, all geometrical types will have to fall under one of these root types.

The names types have then also been expanded for `beam` to include the desired steel beams (`t-beam`, `c-beam`, and `l-beam`) and concrete beams (`y-beam`, `ye-beam`, `m-beam`, `u-beam`, and `um-beam`). The names types also now use a consistent naming convention for the associated dimension names.