### PR TITLE
6 composite materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A structure object must contain the [properties](#structure-properties) required
 ### [Structure Properties](#structure-properties)
 |Property|Description|Type|
 |---|-----|---|
-|`version`|Version of the PBSHM Schema that the document is compliant against. Accepted values: `1.0`, `1.0.1`, `1.1.0`, `1.1.1`|`string`|
+|`version`|Version of the PBSHM Schema that the document is compliant against. Accepted values: `1.0`, `1.0.1`, `1.1.0`, `1.1.1`, `1.2.1`|`string`|
 |`name`|Name of the structure, must be unique within the population (length greater than 1 character)|`string`|
 |`population`|Name of the population that the structure is part of, must be unique within the PBSHM database (length between 1 and 64 characters)|`string`|
 |`timestamp`|Timestamp of when the associated monitoring data was recorded, stored in UTC nanoseconds since UNIX epoch|`long`|

--- a/model-irreducible-element-material-data.json
+++ b/model-irreducible-element-material-data.json
@@ -190,204 +190,8 @@
                     "description": "value of the material property"
                 }
             }
-        }
-    },
-    "bsonType": "object",
-    "title": "material",
-    "description": "material properties of the element",
-    "required": [
-        "type"
-    ],
-    "properties": {
-        "type": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/type"
-                },
-                {
-                    "oneOf": [
-                        {
-                            "properties": {
-                                "name": {
-                                    "enum": [
-                                        "metal"
-                                    ]
-                                },
-                                "type": {
-                                    "oneOf": [
-                                        {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/type"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "ferrousAlloy"
-                                                            ]
-                                                        },
-                                                        "type": {
-                                                            "allOf": [
-                                                                {
-                                                                    "$ref": "#/definitions/type"
-                                                                },
-                                                                {
-                                                                    "properties": {
-                                                                        "name": {
-                                                                            "enum": [
-                                                                                "steel",
-                                                                                "iron"
-                                                                            ]
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": false
-                                                                }
-                                                            ]
-                                                        }
-                                                    },
-                                                    "additionalProperties": false
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "allOf": [
-                                                {
-                                                    "$ref": "#/definitions/type"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "name": {
-                                                            "enum": [
-                                                                "aluminiumAlloy",
-                                                                "nickelAlloy",
-                                                                "copperAlloy",
-                                                                "titaniumAlloy"
-                                                            ]
-                                                        }
-                                                    },
-                                                    "additionalProperties": false
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        {
-                            "properties": {
-                                "name": {
-                                    "enum": [
-                                        "ceramic"
-                                    ]
-                                },
-                                "type": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/definitions/type"
-                                        },
-                                        {
-                                            "properties": {
-                                                "name": {
-                                                    "enum": [
-                                                        "glass",
-                                                        "clayProduct",
-                                                        "refractory",
-                                                        "abrasive",
-                                                        "cement",
-                                                        "advancedCeramic"
-                                                    ]
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        {
-                            "properties": {
-                                "name": {
-                                    "enum": [
-                                        "polymer"
-                                    ]
-                                },
-                                "type": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/definitions/type"
-                                        },
-                                        {
-                                            "properties": {
-                                                "name": {
-                                                    "enum": [
-                                                        "thermoplastic",
-                                                        "thermoset",
-                                                        "elastomer"
-                                                    ]
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        {
-                            "properties": {
-                                "name": {
-                                    "enum": [
-                                        "composite"
-                                    ]
-                                },
-                                "type": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/definitions/type"
-                                        },
-                                        {
-                                            "properties": {
-                                                "name": {
-                                                    "enum": [
-                                                        "particle-reinforced",
-                                                        "fibre-reinforced",
-                                                        "structural"
-                                                    ]
-                                                }
-                                            },
-                                            "additionalProperties": false
-                                        }
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        {
-                            "properties": {
-                                "name": {
-                                    "enum": [
-                                        "other"
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    ]
-                }
-            ]
         },
-        "symmetry": {
-            "bsonType": "string",
-            "title": "symmetry",
-            "description": "symmetry of the material",
-            "enum": [
-                "isotropic"
-            ]
-        },
-        "properties": {
+        "characteristics": {
             "bsonType": "array",
             "title": "properties",
             "description": "array of material properties",
@@ -674,12 +478,273 @@
                 ]
             },
             "minItems": 1
+        },
+        "reference": {
+            "bsonType": "object",
+            "title": "reference material",
+            "description": "reference material properties of the element",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/type"
+                        },
+                        {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "metal"
+                                            ]
+                                        },
+                                        "type": {
+                                            "oneOf": [
+                                                {
+                                                    "allOf": [
+                                                        {
+                                                            "$ref": "#/definitions/type"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "ferrousAlloy"
+                                                                    ]
+                                                                },
+                                                                "type": {
+                                                                    "allOf": [
+                                                                        {
+                                                                            "$ref": "#/definitions/type"
+                                                                        },
+                                                                        {
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "enum": [
+                                                                                        "steel",
+                                                                                        "iron"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "additionalProperties": false
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "allOf": [
+                                                        {
+                                                            "$ref": "#/definitions/type"
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "enum": [
+                                                                        "aluminiumAlloy",
+                                                                        "nickelAlloy",
+                                                                        "copperAlloy",
+                                                                        "titaniumAlloy"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "ceramic"
+                                            ]
+                                        },
+                                        "type": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/type"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "name": {
+                                                            "enum": [
+                                                                "glass",
+                                                                "clayProduct",
+                                                                "refractory",
+                                                                "abrasive",
+                                                                "cement",
+                                                                "advancedCeramic"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "polymer"
+                                            ]
+                                        },
+                                        "type": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/type"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "name": {
+                                                            "enum": [
+                                                                "thermoplastic",
+                                                                "thermoset",
+                                                                "elastomer"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "other"
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "symmetry": {
+                    "bsonType": "string",
+                    "title": "symmetry",
+                    "description": "symmetry of the material",
+                    "enum": [
+                        "isotropic"
+                    ]
+                },
+                "properties": {
+                    "$ref": "#/definitions/characteristics"
+                }
+            },
+            "dependencies": {
+                "properties": [
+                    "symmetry"
+                ]
+            }
         }
     },
-    "dependencies": {
-        "properties": [
-            "symmetry"
-        ]
-    },
-    "additionalProperties": false
+    "oneOf": [
+        {
+            "$ref": "#/definitions/reference"
+        },
+        {
+            "bsonType": "object",
+            "title": "composite material",
+            "description": "composite material properties of the element",
+            "required": [
+                "type",
+                "matrix"
+            ],
+            "properties": {
+                "type": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/type"
+                        },
+                        {
+                            "properties": {
+                                "name": {
+                                    "enum": [
+                                        "composite"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "matrix": {
+                    "bsonType": "object",
+                    "title": "composite material matrix",
+                    "description": "matrix of reference materials to form composite material",
+                    "required": [
+                        "base",
+                        "embedded"
+                    ],
+                    "properties": {
+                        "base": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/reference"
+                                },
+                                {
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        "embedded": {
+                            "bsonType": "array",
+                            "title": "embedded reference materials",
+                            "description": "reference materials embedded within the base material to form the composite material",
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/reference"
+                                    },
+                                    {
+                                        "required": [
+                                            "method"
+                                        ],
+                                        "properties": {
+                                            "method": {
+                                                "bsonType": "string",
+                                                "title": "embedding method",
+                                                "description": "method for embedding the reference material within the base material",
+                                                "enum": [
+                                                    "fibre",
+                                                    "particle",
+                                                    "woven",
+                                                    "bar"
+                                                ]
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "minItems": 1
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "properties": {
+                    "$ref": "#/definitions/characteristics"
+                }
+            },
+            "additionalProperties": false
+        }
+    ]
 }

--- a/model-irreducible-element-material-data.json
+++ b/model-irreducible-element-material-data.json
@@ -613,12 +613,84 @@
                                                             "enum": [
                                                                 "thermoplastic",
                                                                 "thermoset",
-                                                                "elastomer"
+                                                                "elastomer",
+                                                                "resin",
+                                                                "carbon"
                                                             ]
                                                         }
                                                     },
                                                     "additionalProperties": false
                                                 }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "wood"
+                                            ]
+                                        },
+                                        "type": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/type"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "name": {
+                                                            "enum": [
+                                                                "ash",
+                                                                "oak",
+                                                                "maple",
+                                                                "birch",
+                                                                "pine"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "rock"
+                                            ]
+                                        },
+                                        "type": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/type"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "name": {
+                                                            "enum": [
+                                                                "basalt",
+                                                                "marble",
+                                                                "granite"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "properties": {
+                                        "name": {
+                                            "enum": [
+                                                "concrete"
                                             ]
                                         }
                                     },

--- a/structure-data.json
+++ b/structure-data.json
@@ -16,7 +16,7 @@
             "title": "version number",
             "description": "the version of the schema that the document is compliant to",
             "enum": [
-                "1.2.0"
+                "1.2.1"
             ]
         },
         "name": {


### PR DESCRIPTION
To facilitate improved encapsulation of composite materials properties, the material types have been split into two scenarios: `reference` materials which represents single materials that can be used on their own, and `composite` materials which are the combination of a `matrix` of `reference` materials.

A reference material contains the standard `type`, `symmetry`, and `properties` properties as before; however, a composite material declares a `matrix` of materials where there is a `base` reference material which has other reference materials  `embedded` within it.